### PR TITLE
Configure standard JS to lint TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dev": "nodemon --exec \"npm start\"",
     "start": "probot run ./lib/index.js",
     "lint": "standard **/*.ts --fix",
-    "test": "jest && standard",
+    "test": "jest && standard **/*.ts",
     "test:watch": "jest --watch --notify --notifyMode=change --coverage"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "nodemon --exec \"npm start\"",
     "start": "probot run ./lib/index.js",
-    "lint": "standard --fix",
+    "lint": "standard **/*.ts --fix",
     "test": "jest && standard",
     "test:watch": "jest --watch --notify --notifyMode=change --coverage"
   },
@@ -26,19 +26,25 @@
   "devDependencies": {
     "@types/jest": "^23.1.5",
     "@types/node": "^10.5.2",
+    "eslint-plugin-typescript": "^0.12.0",
     "jest": "^23.4.0",
     "nodemon": "^1.17.2",
     "smee-client": "^1.0.2",
     "standard": "^10.0.3",
     "ts-jest": "^23.0.0",
-    "typescript": "^2.9.2"
+    "typescript": "^2.9.2",
+    "typescript-eslint-parser": "^18.0.0"
   },
   "engines": {
     "node": ">= 8.3.0"
   },
   "standard": {
+    "parser": "typescript-eslint-parser",
     "env": [
       "jest"
+    ],
+    "plugins": [
+      "typescript"
     ]
   }
 }


### PR DESCRIPTION
Howdy Probot maintainers! 🤠 

By default, standard only lints JavaScript and JSX files, matching the following patterns: `**/*.js`, `**/*.jsx`.
I went ahead and implemented the configuration suggested by standard to allow it to support Typescript syntax, and to lint `**/*.ts` files: https://standardjs.com/#typescript

Cheers!