### PR TITLE
fixed: appFn is not a function

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "probot-app"
   ],
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc",
     "dev": "nodemon --exec \"npm start\"",
     "start": "probot run ./lib/index.js",
     "lint": "standard **/*.ts --fix",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Application } from 'probot'
 
-export default (app: Application) => {
+export = (app: Application) => {
   // Your code here
   app.log('Yay, the app was loaded!')
 


### PR DESCRIPTION
The probot app crashes with `export default (app: Application) => {...}`, but works with `export = (app: Application) => {...}`.

Steps to reproduce the above error:

1. initialize probot app and accept all 
    > npm init probot-app --typescript sample
    > cd sample
    > npm install
2. configure `.env` file (probot app starts just fine, when `.env` file is missing)
3. build and run
    > npm run build
    > npm run start

	> 10:50:36.868Z ERROR probot: appFn is not a function
	>   TypeError: appFn is not a function
	>       at Application.load (C:\Users\Claas\git\sample\node_modules\probot\lib\application.js:90:13)
	>       at Probot.load (C:\Users\Claas\git\sample\node_modules\probot\lib\index.js:126:13)
	>       at C:\Users\Claas\git\sample\node_modules\probot\lib\index.js:135:78
	>       at Array.forEach (<anonymous>)
	>       at Probot.setup (C:\Users\Claas\git\sample\node_modules\probot\lib\index.js:135:38)
	>       at pkgConf.then.pkg (C:\Users\Claas\git\sample\node_modules\probot\bin\probot-run.js:41:12)